### PR TITLE
Feat/metaplex cli overhaul merged (#334)

### DIFF
--- a/js/packages/cli/src/cli.ts
+++ b/js/packages/cli/src/cli.ts
@@ -1,224 +1,49 @@
 #!/usr/bin/env node
 import * as fs from 'fs';
 import * as path from 'path';
-import fetch from 'node-fetch';
 import FormData from 'form-data';
 import { program } from 'commander';
 import * as anchor from '@project-serum/anchor';
 import BN from 'bn.js';
 import { MintLayout, Token } from '@solana/spl-token';
 
-import { sendTransactionWithRetryWithKeypair, fromUTF8Array } from './helper';
 import {
-  LAMPORTS_PER_SOL,
-  PublicKey,
-  SystemProgram,
-  SYSVAR_RENT_PUBKEY,
-  TransactionInstruction,
-} from '@solana/web3.js';
+  chunks,
+  fromUTF8Array,
+  loadCache,
+  parsePrice,
+  saveCache,
+  upload,
+} from './helpers/various';
+import { Keypair, PublicKey, SystemProgram } from '@solana/web3.js';
+import { createAssociatedTokenAccountInstruction } from './helpers/instructions';
+import {
+  CACHE_PATH,
+  CONFIG_ARRAY_START,
+  CONFIG_LINE_SIZE,
+  EXTENSION_JSON,
+  EXTENSION_PNG,
+  PAYMENT_WALLET,
+  TOKEN_METADATA_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from './helpers/constants';
+import { sendTransactionWithRetryWithKeypair } from './helpers/transactions';
+import {
+  createConfig,
+  getCandyMachineAddress,
+  getMasterEdition,
+  getMetadata,
+  getTokenWallet,
+  loadAnchorProgram,
+  loadWalletKey,
+} from './helpers/accounts';
+import { Config } from './types';
 
-const CACHE_PATH = './.cache';
-const PAYMENT_WALLET = new anchor.web3.PublicKey(
-  'HvwC9QSAzvGXhhVrgPmauVwFWcYZhne3hVot9EbHuFTm',
-);
-const CANDY_MACHINE = 'candy_machine';
-
-const programId = new anchor.web3.PublicKey(
-  'cndyAnrLdpjq1Ssp1z8xxDsB8dxe7u4HL5Nxi2K5WXZ',
-);
-const TOKEN_METADATA_PROGRAM_ID = new PublicKey(
-  'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
-);
-
-const SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID = new PublicKey(
-  'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
-);
-const TOKEN_PROGRAM_ID = new PublicKey(
-  'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-);
-const getTokenWallet = async function (wallet: PublicKey, mint: PublicKey) {
-  return (
-    await PublicKey.findProgramAddress(
-      [wallet.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mint.toBuffer()],
-      SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
-    )
-  )[0];
-};
-
-export function createAssociatedTokenAccountInstruction(
-  associatedTokenAddress: PublicKey,
-  payer: PublicKey,
-  walletAddress: PublicKey,
-  splTokenMintAddress: PublicKey,
-) {
-  const keys = [
-    {
-      pubkey: payer,
-      isSigner: true,
-      isWritable: true,
-    },
-    {
-      pubkey: associatedTokenAddress,
-      isSigner: false,
-      isWritable: true,
-    },
-    {
-      pubkey: walletAddress,
-      isSigner: false,
-      isWritable: false,
-    },
-    {
-      pubkey: splTokenMintAddress,
-      isSigner: false,
-      isWritable: false,
-    },
-    {
-      pubkey: SystemProgram.programId,
-      isSigner: false,
-      isWritable: false,
-    },
-    {
-      pubkey: TOKEN_PROGRAM_ID,
-      isSigner: false,
-      isWritable: false,
-    },
-    {
-      pubkey: SYSVAR_RENT_PUBKEY,
-      isSigner: false,
-      isWritable: false,
-    },
-  ];
-  return new TransactionInstruction({
-    keys,
-    programId: SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
-    data: Buffer.from([]),
-  });
-}
-
-function chunks(array, size) {
-  return Array.apply(0, new Array(Math.ceil(array.length / size))).map(
-    (_, index) => array.slice(index * size, (index + 1) * size),
-  );
-}
-
-const configArrayStart =
-  32 + // authority
-  4 +
-  6 + // uuid + u32 len
-  4 +
-  10 + // u32 len + symbol
-  2 + // seller fee basis points
-  1 +
-  4 +
-  5 * 34 + // optional + u32 len + actual vec
-  8 + //max supply
-  1 + //is mutable
-  1 + // retain authority
-  4; // max number of lines;
-const configLineSize = 4 + 32 + 4 + 200;
 program.version('0.0.1');
 
 if (!fs.existsSync(CACHE_PATH)) {
   fs.mkdirSync(CACHE_PATH);
 }
-
-const getCandyMachine = async (config: anchor.web3.PublicKey, uuid: string) => {
-  return await anchor.web3.PublicKey.findProgramAddress(
-    [Buffer.from(CANDY_MACHINE), config.toBuffer(), Buffer.from(uuid)],
-    programId,
-  );
-};
-
-const getMetadata = async (
-  mint: anchor.web3.PublicKey,
-): Promise<anchor.web3.PublicKey> => {
-  return (
-    await anchor.web3.PublicKey.findProgramAddress(
-      [
-        Buffer.from('metadata'),
-        TOKEN_METADATA_PROGRAM_ID.toBuffer(),
-        mint.toBuffer(),
-      ],
-      TOKEN_METADATA_PROGRAM_ID,
-    )
-  )[0];
-};
-
-const getMasterEdition = async (
-  mint: anchor.web3.PublicKey,
-): Promise<anchor.web3.PublicKey> => {
-  return (
-    await anchor.web3.PublicKey.findProgramAddress(
-      [
-        Buffer.from('metadata'),
-        TOKEN_METADATA_PROGRAM_ID.toBuffer(),
-        mint.toBuffer(),
-        Buffer.from('edition'),
-      ],
-      TOKEN_METADATA_PROGRAM_ID,
-    )
-  )[0];
-};
-
-const createConfig = async function (
-  anchorProgram: anchor.Program,
-  payerWallet: anchor.web3.Keypair,
-  configData: {
-    maxNumberOfLines: BN;
-    symbol: string;
-    sellerFeeBasisPoints: number;
-    isMutable: boolean;
-    maxSupply: BN;
-    retainAuthority: boolean;
-    creators: {
-      address: anchor.web3.PublicKey;
-      verified: boolean;
-      share: number;
-    }[];
-  },
-) {
-  const size =
-    configArrayStart +
-    4 +
-    configData.maxNumberOfLines.toNumber() * configLineSize +
-    4 +
-    Math.ceil(configData.maxNumberOfLines.toNumber() / 8);
-
-  const config = anchor.web3.Keypair.generate();
-  const uuid = config.publicKey.toBase58().slice(0, 6);
-  return {
-    config: config.publicKey,
-    uuid,
-    txId: await anchorProgram.rpc.initializeConfig(
-      {
-        uuid,
-        ...configData,
-      },
-      {
-        accounts: {
-          config: config.publicKey,
-          authority: payerWallet.publicKey,
-          payer: payerWallet.publicKey,
-          systemProgram: anchor.web3.SystemProgram.programId,
-          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        },
-        signers: [payerWallet, config],
-        instructions: [
-          anchor.web3.SystemProgram.createAccount({
-            fromPubkey: payerWallet.publicKey,
-            newAccountPubkey: config.publicKey,
-            space: size,
-            lamports:
-              await anchorProgram.provider.connection.getMinimumBalanceForRentExemption(
-                size,
-              ),
-            programId: programId,
-          }),
-        ],
-      },
-    ),
-  };
-};
 
 program
   .command('upload')
@@ -230,25 +55,42 @@ program
     },
   )
   .option(
-    '-u, --url',
-    'Solana cluster url',
-    'https://api.mainnet-beta.solana.com/',
+    '-e, --env <string>',
+    'Solana cluster env name',
+    'devnet', //mainnet-beta, testnet, devnet
   )
-  .option('-k, --keypair <path>', 'Solana wallet')
+  .option(
+    '-k, --keypair <path>',
+    `Solana wallet location`,
+    '--keypair not provided',
+  )
   // .argument('[second]', 'integer argument', (val) => parseInt(val), 1000)
-  .option('-s, --start-with', 'Image index to start with', '0')
-  .option('-n, --number', 'Number of images to upload', '10000')
-  .option('-c, --cache-name <path>', 'Cache file name')
-  .option('-e, --env <name>', 'Environment')
+  .option('-n, --number <number>', 'Number of images to upload')
+  .option('-c, --cache-name <string>', 'Cache file name', 'temp')
   .action(async (files: string[], options, cmd) => {
-    const extension = '.png';
-    const { keypair } = cmd.opts();
-    const cacheName = program.getOptionValue('cacheName') || 'temp';
-    const ENV = program.getOptionValue('env') || 'devnet';
-    const cachePath = path.join(CACHE_PATH, cacheName);
-    const savedContent = fs.existsSync(cachePath)
-      ? JSON.parse(fs.readFileSync(cachePath).toString())
-      : undefined;
+    const { number, keypair, env, cacheName } = cmd.opts();
+    const parsedNumber = parseInt(number);
+
+    const pngFileCount = files.filter(it => {
+      return it.endsWith(EXTENSION_PNG);
+    }).length;
+    const jsonFileCount = files.filter(it => {
+      return it.endsWith(EXTENSION_JSON);
+    }).length;
+
+    if (pngFileCount !== jsonFileCount) {
+      throw new Error(
+        `number of png files (${pngFileCount}) is different than the number of json files (${jsonFileCount})`,
+      );
+    }
+
+    if (parsedNumber < pngFileCount) {
+      throw new Error(
+        `max number (${parsedNumber})cannot be smaller than the number of elements in the source folder (${pngFileCount})`,
+      );
+    }
+
+    const savedContent = loadCache(cacheName, env);
     const cacheContent = savedContent || {};
 
     if (!cacheContent.program) {
@@ -266,8 +108,8 @@ program
     const newFiles = [];
 
     files.forEach(f => {
-      if (!seen[f.replace(extension, '').split('/').pop()]) {
-        seen[f.replace(extension, '').split('/').pop()] = true;
+      if (!seen[f.replace(EXTENSION_PNG, '').split('/').pop()]) {
+        seen[f.replace(EXTENSION_PNG, '').split('/').pop()] = true;
         newFiles.push(f);
       }
     });
@@ -278,41 +120,20 @@ program
       }
     });
 
-    const images = newFiles.filter(val => path.extname(val) === extension);
-    const SIZE = images.length; // images.length;
-    const walletKey = anchor.web3.Keypair.fromSecretKey(
-      new Uint8Array(JSON.parse(fs.readFileSync(keypair).toString())),
-    );
+    const images = newFiles.filter(val => path.extname(val) === EXTENSION_PNG);
+    const SIZE = images.length;
 
-    // const conversionRates = JSON.parse(
-    //   await (
-    //     await fetch(
-    //       'https://api.coingecko.com/api/v3/simple/price?ids=solana,arweave&vs_currencies=usd',
-    //     )
-    //   ).text(),
-    // );
-    // const baseCost = fetch(``);
-    // const increment = fetch(``);
+    const walletKeyPair = loadWalletKey(keypair);
+    const anchorProgram = await loadAnchorProgram(walletKeyPair, env);
 
-    const solConnection = new anchor.web3.Connection(
-      `https://api.${ENV}.solana.com/`,
-    );
-
-    const walletWrapper = new anchor.Wallet(walletKey);
-    const provider = new anchor.Provider(solConnection, walletWrapper, {
-      preflightCommitment: 'recent',
-    });
-    const idl = await anchor.Program.fetchIdl(programId, provider);
-    const anchorProgram = new anchor.Program(idl, programId, provider);
     let config = cacheContent.program.config
-      ? new anchor.web3.PublicKey(cacheContent.program.config)
+      ? new PublicKey(cacheContent.program.config)
       : undefined;
 
-    await solConnection.getRecentBlockhash();
     for (let i = 0; i < SIZE; i++) {
       const image = images[i];
       const imageName = path.basename(image);
-      const index = imageName.replace(extension, '');
+      const index = imageName.replace(EXTENSION_PNG, '');
 
       console.log(`Processing file: ${index}`);
 
@@ -320,8 +141,7 @@ program
 
       let link = cacheContent?.items?.[index]?.link;
       if (!link || !cacheContent.program.uuid) {
-        // const imageBuffer = Buffer.from(fs.readFileSync(image));
-        const manifestPath = image.replace(extension, '.json');
+        const manifestPath = image.replace(EXTENSION_PNG, '.json');
         const manifestContent = fs
           .readFileSync(manifestPath)
           .toString()
@@ -330,13 +150,13 @@ program
         const manifest = JSON.parse(manifestContent);
 
         const manifestBuffer = Buffer.from(JSON.stringify(manifest));
-        // const sizeInBytes = imageBuffer.length + manifestBuffer.length;
 
         if (i === 0 && !cacheContent.program.uuid) {
           // initialize config
+          console.log(`initializing config`);
           try {
-            const res = await createConfig(anchorProgram, walletKey, {
-              maxNumberOfLines: new BN(SIZE),
+            const res = await createConfig(anchorProgram, walletKeyPair, {
+              maxNumberOfLines: new BN(parsedNumber || SIZE),
               symbol: manifest.symbol,
               sellerFeeBasisPoints: manifest.seller_fee_basis_points,
               isMutable: true,
@@ -344,8 +164,8 @@ program
               retainAuthority: true,
               creators: manifest.properties.creators.map(creator => {
                 return {
-                  address: new anchor.web3.PublicKey(creator.address),
-                  verified: false,
+                  address: new PublicKey(creator.address),
+                  verified: true,
                   share: creator.share,
                 };
               }),
@@ -354,10 +174,11 @@ program
             cacheContent.program.config = res.config.toBase58();
             config = res.config;
 
-            fs.writeFileSync(
-              path.join(CACHE_PATH, cacheName),
-              JSON.stringify(cacheContent),
+            console.log(
+              `initialized config for a candy machine with uuid: ${res.uuid}`,
             );
+
+            saveCache(cacheName, env, cacheContent);
           } catch (exx) {
             console.error('Error deploying config to Solana network.', exx);
             // console.error(exx);
@@ -367,15 +188,15 @@ program
         if (!link) {
           const instructions = [
             anchor.web3.SystemProgram.transfer({
-              fromPubkey: walletKey.publicKey,
+              fromPubkey: walletKeyPair.publicKey,
               toPubkey: PAYMENT_WALLET,
               lamports: storageCost,
             }),
           ];
 
           const tx = await sendTransactionWithRetryWithKeypair(
-            solConnection,
-            walletKey,
+            anchorProgram.provider.connection,
+            walletKeyPair,
             instructions,
             [],
             'single',
@@ -386,19 +207,14 @@ program
           // payment transaction
           const data = new FormData();
           data.append('transaction', tx['txid']);
-          data.append('env', ENV);
-          data.append('file[]', fs.createReadStream(image), `image.png`);
+          data.append('env', env);
+          data.append('file[]', fs.createReadStream(image), {
+            filename: `image.png`,
+            contentType: 'image/png',
+          });
           data.append('file[]', manifestBuffer, 'metadata.json');
           try {
-            const result = await (
-              await fetch(
-                'https://us-central1-principal-lane-200702.cloudfunctions.net/uploadFile3',
-                {
-                  method: 'POST',
-                  body: data,
-                },
-              )
-            ).json();
+            const result = await upload(data, manifest, index);
 
             const metadataFile = result.messages?.find(
               m => m.filename === 'manifest.json',
@@ -407,16 +223,13 @@ program
               link = `https://arweave.net/${metadataFile.transactionId}`;
               console.log(`File uploaded: ${link}`);
             }
-
+            console.log('setting cache for ', index);
             cacheContent.items[index] = {
               link,
               name: manifest.name,
               onChain: false,
             };
-            fs.writeFileSync(
-              path.join(CACHE_PATH, cacheName),
-              JSON.stringify(cacheContent),
-            );
+            saveCache(cacheName, env, cacheContent);
           } catch (er) {
             console.error(`Error uploading file ${index}`, er);
           }
@@ -424,6 +237,7 @@ program
       }
     }
 
+    let updateSuccessful = true;
     const keys = Object.keys(cacheContent.items);
     try {
       await Promise.all(
@@ -443,35 +257,39 @@ program
 
               if (onChain.length != indexes.length) {
                 console.log(
-                  'Writing indices ',
-                  ind,
-                  '-',
-                  keys[indexes[indexes.length - 1]],
+                  `Writing indices ${ind}-${keys[indexes[indexes.length - 1]]}`,
                 );
-                await anchorProgram.rpc.addConfigLines(
-                  ind,
-                  indexes.map(i => ({
-                    uri: cacheContent.items[keys[i]].link,
-                    name: cacheContent.items[keys[i]].name,
-                  })),
-                  {
-                    accounts: {
-                      config,
-                      authority: walletKey.publicKey,
+                try {
+                  await anchorProgram.rpc.addConfigLines(
+                    ind,
+                    indexes.map(i => ({
+                      uri: cacheContent.items[keys[i]].link,
+                      name: cacheContent.items[keys[i]].name,
+                    })),
+                    {
+                      accounts: {
+                        config,
+                        authority: walletKeyPair.publicKey,
+                      },
+                      signers: [walletKeyPair],
                     },
-                    signers: [walletKey],
-                  },
-                );
-                indexes.forEach(i => {
-                  cacheContent.items[keys[i]] = {
-                    ...cacheContent.items[keys[i]],
-                    onChain: true,
-                  };
-                });
-                fs.writeFileSync(
-                  path.join(CACHE_PATH, cacheName),
-                  JSON.stringify(cacheContent),
-                );
+                  );
+                  indexes.forEach(i => {
+                    cacheContent.items[keys[i]] = {
+                      ...cacheContent.items[keys[i]],
+                      onChain: true,
+                    };
+                  });
+                  saveCache(cacheName, env, cacheContent);
+                } catch (e) {
+                  console.log(
+                    `saving config line ${ind}-${
+                      keys[indexes[indexes.length - 1]]
+                    } failed`,
+                    e,
+                  );
+                  updateSuccessful = false;
+                }
               }
             }
           },
@@ -480,250 +298,48 @@ program
     } catch (e) {
       console.error(e);
     } finally {
-      fs.writeFileSync(
-        path.join(CACHE_PATH, cacheName),
-        JSON.stringify(cacheContent),
-      );
+      saveCache(cacheName, env, cacheContent);
     }
-    console.log('Done');
-    // TODO: start candy machine
-  });
-program
-  .command('set_start_date')
-  .option('-k, --keypair <path>', 'Solana wallet')
-  .option('-c, --cache-name <path>', 'Cache file name')
-  .option('-d, --date <string>', 'timestamp - eg "04 Dec 1995 00:12:00 GMT"')
-  .option('-e, --env <name>', 'Environment')
-  .action(async (directory, cmd) => {
-    const ENV = program.getOptionValue('env') || 'devnet';
-    const solConnection = new anchor.web3.Connection(
-      `https://api.${ENV}.solana.com/`,
-    );
-
-    const { keypair } = cmd.opts();
-
-    const cacheName = cmd.getOptionValue('cacheName') || 'temp';
-    const cachePath = path.join(CACHE_PATH, cacheName);
-    const cachedContent = fs.existsSync(cachePath)
-      ? JSON.parse(fs.readFileSync(cachePath).toString())
-      : undefined;
-
-    const date = cmd.getOptionValue('date');
-    const secondsSinceEpoch = (date ? Date.parse(date) : Date.now()) / 1000;
-    const walletKey = anchor.web3.Keypair.fromSecretKey(
-      new Uint8Array(JSON.parse(fs.readFileSync(keypair).toString())),
-    );
-    const walletWrapper = new anchor.Wallet(walletKey);
-    const provider = new anchor.Provider(solConnection, walletWrapper, {
-      preflightCommitment: 'recent',
-    });
-    const idl = await anchor.Program.fetchIdl(programId, provider);
-    const anchorProgram = new anchor.Program(idl, programId, provider);
-    const [candyMachine] = await getCandyMachine(
-      new anchor.web3.PublicKey(cachedContent.program.config),
-      cachedContent.program.uuid,
-    );
-    const tx = await anchorProgram.rpc.updateCandyMachine(
-      null,
-      new anchor.BN(secondsSinceEpoch),
-      {
-        accounts: {
-          candyMachine,
-          authority: walletKey.publicKey,
-        },
-      },
-    );
-
-    console.log('Done', secondsSinceEpoch, tx);
+    console.log(`Done. Successful = ${updateSuccessful}. If 'false' - rerun`);
   });
 
-program
-  .command('create_candy_machine')
-  .option('-k, --keypair <path>', 'Solana wallet')
-  .option('-c, --cache-name <path>', 'Cache file name')
-  .option('-p, --price <string>', 'SOL price')
-  .option('-e, --env <name>', 'Environment')
-  .action(async (directory, cmd) => {
-    const ENV = program.getOptionValue('env') || 'devnet';
-    const solConnection = new anchor.web3.Connection(
-      `https://api.${ENV}.solana.com/`,
-    );
-
-    const { keypair } = cmd.opts();
-    const solPriceStr = cmd.getOptionValue('price') || '1';
-
-    const lamports = Math.ceil(parseFloat(solPriceStr) * LAMPORTS_PER_SOL);
-
-    const cacheName = program.getOptionValue('cacheName') || 'temp';
-    const cachePath = path.join(CACHE_PATH, cacheName);
-    const cachedContent = fs.existsSync(cachePath)
-      ? JSON.parse(fs.readFileSync(cachePath).toString())
-      : undefined;
-
-    const walletKey = anchor.web3.Keypair.fromSecretKey(
-      new Uint8Array(JSON.parse(fs.readFileSync(keypair).toString())),
-    );
-    const walletWrapper = new anchor.Wallet(walletKey);
-    const provider = new anchor.Provider(solConnection, walletWrapper, {
-      preflightCommitment: 'recent',
-    });
-    const idl = await anchor.Program.fetchIdl(programId, provider);
-    const anchorProgram = new anchor.Program(idl, programId, provider);
-    const config = new anchor.web3.PublicKey(cachedContent.program.config);
-    const [candyMachine, bump] = await getCandyMachine(
-      config,
-      cachedContent.program.uuid,
-    );
-    await anchorProgram.rpc.initializeCandyMachine(
-      bump,
-      {
-        uuid: cachedContent.program.uuid,
-        price: new anchor.BN(lamports),
-        itemsAvailable: new anchor.BN(Object.keys(cachedContent.items).length),
-        goLiveDate: null,
-      },
-      {
-        accounts: {
-          candyMachine,
-          wallet: walletKey.publicKey,
-          config: config,
-          authority: walletKey.publicKey,
-          payer: walletKey.publicKey,
-          systemProgram: anchor.web3.SystemProgram.programId,
-          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        },
-        signers: [],
-      },
-    );
-
-    console.log(`Done: CANDYMACHINE: ${candyMachine.toBase58()}`);
-  });
-
-program
-  .command('mint_one_token')
-  .option('-k, --keypair <path>', `The purchaser's wallet key`)
-  .option('-c, --cache-name <path>', 'Cache file name')
-  .option('-e, --env <name>', 'Environment')
-  .action(async (directory, cmd) => {
-    const ENV = program.getOptionValue('env') || 'devnet';
-    const solConnection = new anchor.web3.Connection(
-      `https://api.${ENV}.solana.com/`,
-    );
-
-    const { keypair } = cmd.opts();
-    // const solPriceStr = program.getOptionValue('price') || '1';
-    // const lamports = parseInt(solPriceStr) * LAMPORTS_PER_SOL;
-
-    const cacheName = program.getOptionValue('cacheName') || 'temp';
-    const cachePath = path.join(CACHE_PATH, cacheName);
-    const cachedContent = fs.existsSync(cachePath)
-      ? JSON.parse(fs.readFileSync(cachePath).toString())
-      : undefined;
-    const mint = anchor.web3.Keypair.generate();
-
-    const walletKey = anchor.web3.Keypair.fromSecretKey(
-      new Uint8Array(JSON.parse(fs.readFileSync(keypair).toString())),
-    );
-    const token = await getTokenWallet(walletKey.publicKey, mint.publicKey);
-    const walletWrapper = new anchor.Wallet(walletKey);
-    const provider = new anchor.Provider(solConnection, walletWrapper, {
-      preflightCommitment: 'recent',
-    });
-    const idl = await anchor.Program.fetchIdl(programId, provider);
-    const anchorProgram = new anchor.Program(idl, programId, provider);
-    const config = new anchor.web3.PublicKey(cachedContent.program.config);
-    const [candyMachine] = await getCandyMachine(
-      config,
-      cachedContent.program.uuid,
-    );
-    const candy = await anchorProgram.account.candyMachine.fetch(candyMachine);
-    const metadata = await getMetadata(mint.publicKey);
-    const masterEdition = await getMasterEdition(mint.publicKey);
-    const tx = await anchorProgram.rpc.mintNft({
-      accounts: {
-        config: config,
-        candyMachine: candyMachine,
-        payer: walletKey.publicKey,
-        //@ts-ignore
-        wallet: candy.wallet,
-        mint: mint.publicKey,
-        metadata,
-        masterEdition,
-        mintAuthority: walletKey.publicKey,
-        updateAuthority: walletKey.publicKey,
-        tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID,
-        tokenProgram: TOKEN_PROGRAM_ID,
-        systemProgram: SystemProgram.programId,
-        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
-      },
-      signers: [mint, walletKey],
-      instructions: [
-        anchor.web3.SystemProgram.createAccount({
-          fromPubkey: walletKey.publicKey,
-          newAccountPubkey: mint.publicKey,
-          space: MintLayout.span,
-          lamports: await provider.connection.getMinimumBalanceForRentExemption(
-            MintLayout.span,
-          ),
-          programId: TOKEN_PROGRAM_ID,
-        }),
-        Token.createInitMintInstruction(
-          TOKEN_PROGRAM_ID,
-          mint.publicKey,
-          0,
-          walletKey.publicKey,
-          walletKey.publicKey,
-        ),
-        createAssociatedTokenAccountInstruction(
-          token,
-          walletKey.publicKey,
-          walletKey.publicKey,
-          mint.publicKey,
-        ),
-        Token.createMintToInstruction(
-          TOKEN_PROGRAM_ID,
-          mint.publicKey,
-          token,
-          walletKey.publicKey,
-          [],
-          1,
-        ),
-      ],
-    });
-
-    console.log('Done', tx);
-  });
 program
   .command('verify')
-  .option('-c, --cache-name <path>', 'Cache file name')
-  .option('-e, --env <name>', 'Environment')
-  .action(async (directory, second, options) => {
-    const ENV = program.getOptionValue('env') || 'devnet';
-    const solConnection = new anchor.web3.Connection(
-      `https://api.${ENV}.solana.com/`,
-    );
-    const cacheName = program.getOptionValue('cacheName') || 'temp';
-    const cachePath = path.join(CACHE_PATH, cacheName);
-    const cachedContent = fs.existsSync(cachePath)
-      ? JSON.parse(fs.readFileSync(cachePath).toString())
-      : undefined;
+  .option(
+    '-e, --env <string>',
+    'Solana cluster env name',
+    'devnet', //mainnet-beta, testnet, devnet
+  )
+  .option(
+    '-k, --keypair <path>',
+    `Solana wallet location`,
+    '--keypair not provided',
+  )
+  .option('-c, --cache-name <string>', 'Cache file name', 'temp')
+  .action(async (directory, cmd) => {
+    const { env, keypair, cacheName } = cmd.opts();
 
-    const config = await solConnection.getAccountInfo(
-      new PublicKey(cachedContent.program.config),
-    );
+    const cacheContent = loadCache(cacheName, env);
+    const walletKeyPair = loadWalletKey(keypair);
+    const anchorProgram = await loadAnchorProgram(walletKeyPair, env);
 
-    const keys = Object.keys(cachedContent.items);
+    const configAddress = new PublicKey(cacheContent.program.config);
+    const config = await anchorProgram.provider.connection.getAccountInfo(
+      configAddress,
+    );
+    let allGood = true;
+
+    const keys = Object.keys(cacheContent.items);
     for (let i = 0; i < keys.length; i++) {
       console.log('Looking at key ', i);
       const key = keys[i];
       const thisSlice = config.data.slice(
-        configArrayStart + 4 + configLineSize * i,
-        configArrayStart + 4 + configLineSize * (i + 1),
+        CONFIG_ARRAY_START + 4 + CONFIG_LINE_SIZE * i,
+        CONFIG_ARRAY_START + 4 + CONFIG_LINE_SIZE * (i + 1),
       );
       const name = fromUTF8Array([...thisSlice.slice(4, 36)]);
       const uri = fromUTF8Array([...thisSlice.slice(40, 240)]);
-      const cacheItem = cachedContent.items[key];
+      const cacheItem = cacheContent.items[key];
       if (!name.match(cacheItem.name) || !uri.match(cacheItem.link)) {
         console.log(
           'Name',
@@ -738,14 +354,231 @@ program
           key,
         );
         cacheItem.onChain = false;
+        allGood = false;
       } else {
-        console.log('Name', name, 'with', uri, 'checked out');
+        console.debug('Name', name, 'with', uri, 'checked out');
       }
     }
-    fs.writeFileSync(
-      path.join(CACHE_PATH, cacheName),
-      JSON.stringify(cachedContent),
+
+    if (!allGood) {
+      saveCache(cacheName, env, cacheContent);
+
+      throw new Error(
+        `not all NFTs checked out. check out logs above for details`,
+      );
+    }
+
+    const configData = (await anchorProgram.account.config.fetch(
+      configAddress,
+    )) as Config;
+
+    const lineCount = new BN(config.data.slice(247, 247 + 4), undefined, 'le');
+
+    console.log(
+      `uploaded (${lineCount.toNumber()}) out of (${
+        configData.data.maxNumberOfLines
+      })`,
     );
+    if (configData.data.maxNumberOfLines > lineCount.toNumber()) {
+      throw new Error(
+        `predefined number of NFTs (${
+          configData.data.maxNumberOfLines
+        }) is smaller than the uploaded one (${lineCount.toNumber()})`,
+      );
+    } else {
+      console.log('ready to deploy!');
+    }
+
+    saveCache(cacheName, env, cacheContent);
+  });
+
+program
+  .command('create_candy_machine')
+  .option(
+    '-e, --env <string>',
+    'Solana cluster env name',
+    'devnet', //mainnet-beta, testnet, devnet
+  )
+  .option(
+    '-k, --keypair <path>',
+    `Solana wallet location`,
+    '--keypair not provided',
+  )
+  .option('-c, --cache-name <string>', 'Cache file name', 'temp')
+  .option('-p, --price <string>', 'SOL price', '1')
+  .action(async (directory, cmd) => {
+    const { keypair, env, price, cacheName } = cmd.opts();
+
+    const lamports = parsePrice(price);
+    const cacheContent = loadCache(cacheName, env);
+
+    const walletKeyPair = loadWalletKey(keypair);
+    const anchorProgram = await loadAnchorProgram(walletKeyPair, env);
+
+    const config = new PublicKey(cacheContent.program.config);
+    const [candyMachine, bump] = await getCandyMachineAddress(
+      config,
+      cacheContent.program.uuid,
+    );
+    await anchorProgram.rpc.initializeCandyMachine(
+      bump,
+      {
+        uuid: cacheContent.program.uuid,
+        price: new anchor.BN(lamports),
+        itemsAvailable: new anchor.BN(Object.keys(cacheContent.items).length),
+        goLiveDate: null,
+      },
+      {
+        accounts: {
+          candyMachine,
+          wallet: walletKeyPair.publicKey,
+          config: config,
+          authority: walletKeyPair.publicKey,
+          payer: walletKeyPair.publicKey,
+          systemProgram: anchor.web3.SystemProgram.programId,
+          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        },
+        signers: [],
+      },
+    );
+
+    console.log(`create_candy_machine Done: ${candyMachine.toBase58()}`);
+  });
+
+program
+  .command('set_start_date')
+  .option(
+    '-e, --env <string>',
+    'Solana cluster env name',
+    'devnet', //mainnet-beta, testnet, devnet
+  )
+  .option(
+    '-k, --keypair <path>',
+    `Solana wallet location`,
+    '--keypair not provided',
+  )
+  .option('-c, --cache-name <string>', 'Cache file name', 'temp')
+  .option('-d, --date <string>', 'timestamp - eg "04 Dec 1995 00:12:00 GMT"')
+  .action(async (directory, cmd) => {
+    const { keypair, env, date, cacheName } = cmd.opts();
+    const cacheContent = loadCache(cacheName, env);
+
+    const secondsSinceEpoch = (date ? Date.parse(date) : Date.now()) / 1000;
+
+    const walletKeyPair = loadWalletKey(keypair);
+    const anchorProgram = await loadAnchorProgram(walletKeyPair, env);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [candyMachine, _] = await getCandyMachineAddress(
+      new PublicKey(cacheContent.program.config),
+      cacheContent.program.uuid,
+    );
+    const tx = await anchorProgram.rpc.updateCandyMachine(
+      null,
+      new anchor.BN(secondsSinceEpoch),
+      {
+        accounts: {
+          candyMachine,
+          authority: walletKeyPair.publicKey,
+        },
+      },
+    );
+
+    console.log('set_start_date Done', secondsSinceEpoch, tx);
+  });
+
+program
+  .command('mint_one_token')
+  .option(
+    '-e, --env <string>',
+    'Solana cluster env name',
+    'devnet', //mainnet-beta, testnet, devnet
+  )
+  .option(
+    '-k, --keypair <path>',
+    `Solana wallet location`,
+    '--keypair not provided',
+  )
+  .option('-c, --cache-name <string>', 'Cache file name', 'temp')
+  .action(async (directory, cmd) => {
+    const { keypair, env, cacheName } = cmd.opts();
+
+    const cacheContent = loadCache(cacheName, env);
+    const mint = Keypair.generate();
+
+    const walletKeyPair = loadWalletKey(keypair);
+    const anchorProgram = await loadAnchorProgram(walletKeyPair, env);
+    const userTokenAccountAddress = await getTokenWallet(
+      walletKeyPair.publicKey,
+      mint.publicKey,
+    );
+
+    const configAddress = new PublicKey(cacheContent.program.config);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [candyMachineAddress, bump] = await getCandyMachineAddress(
+      configAddress,
+      cacheContent.program.uuid,
+    );
+    const candyMachine = await anchorProgram.account.candyMachine.fetch(
+      candyMachineAddress,
+    );
+    const metadataAddress = await getMetadata(mint.publicKey);
+    const masterEdition = await getMasterEdition(mint.publicKey);
+    const tx = await anchorProgram.rpc.mintNft({
+      accounts: {
+        config: configAddress,
+        candyMachine: candyMachineAddress,
+        payer: walletKeyPair.publicKey,
+        //@ts-ignore
+        wallet: candyMachine.wallet,
+        mint: mint.publicKey,
+        metadata: metadataAddress,
+        masterEdition,
+        mintAuthority: walletKeyPair.publicKey,
+        updateAuthority: walletKeyPair.publicKey,
+        tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
+      },
+      signers: [mint, walletKeyPair],
+      instructions: [
+        anchor.web3.SystemProgram.createAccount({
+          fromPubkey: walletKeyPair.publicKey,
+          newAccountPubkey: mint.publicKey,
+          space: MintLayout.span,
+          lamports:
+            await anchorProgram.provider.connection.getMinimumBalanceForRentExemption(
+              MintLayout.span,
+            ),
+          programId: TOKEN_PROGRAM_ID,
+        }),
+        Token.createInitMintInstruction(
+          TOKEN_PROGRAM_ID,
+          mint.publicKey,
+          0,
+          walletKeyPair.publicKey,
+          walletKeyPair.publicKey,
+        ),
+        createAssociatedTokenAccountInstruction(
+          userTokenAccountAddress,
+          walletKeyPair.publicKey,
+          walletKeyPair.publicKey,
+          mint.publicKey,
+        ),
+        Token.createMintToInstruction(
+          TOKEN_PROGRAM_ID,
+          mint.publicKey,
+          userTokenAccountAddress,
+          walletKeyPair.publicKey,
+          [],
+          1,
+        ),
+      ],
+    });
+
+    console.log('Done', tx);
   });
 
 program.command('find-wallets').action(() => {});

--- a/js/packages/cli/src/helpers/accounts.ts
+++ b/js/packages/cli/src/helpers/accounts.ts
@@ -1,0 +1,144 @@
+import {Keypair, PublicKey, SystemProgram} from '@solana/web3.js';
+import {
+  CANDY_MACHINE,
+  CANDY_MACHINE_PROGRAM_ID,
+  SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+  TOKEN_METADATA_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from './constants';
+import * as anchor from '@project-serum/anchor';
+import fs from 'fs';
+import BN from "bn.js";
+import {createConfigAccount} from "./instructions";
+
+export const createConfig = async function (
+  anchorProgram: anchor.Program,
+  payerWallet: Keypair,
+  configData: {
+    maxNumberOfLines: BN;
+    symbol: string;
+    sellerFeeBasisPoints: number;
+    isMutable: boolean;
+    maxSupply: BN;
+    retainAuthority: boolean;
+    creators: {
+      address: PublicKey;
+      verified: boolean;
+      share: number;
+    }[];
+  },
+) {
+  const configAccount = Keypair.generate();
+  const uuid = configAccount.publicKey.toBase58().slice(0, 6);
+
+  return {
+    config: configAccount.publicKey,
+    uuid,
+    txId: await anchorProgram.rpc.initializeConfig(
+      {
+        uuid,
+        ...configData,
+      },
+      {
+        accounts: {
+          config: configAccount.publicKey,
+          authority: payerWallet.publicKey,
+          payer: payerWallet.publicKey,
+          systemProgram: SystemProgram.programId,
+          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        },
+        signers: [payerWallet, configAccount],
+        instructions: [
+          await createConfigAccount(
+            anchorProgram,
+            configData,
+            payerWallet.publicKey,
+            configAccount.publicKey,
+          ),
+        ],
+      },
+    ),
+  };
+};
+
+export const getTokenWallet = async function (
+  wallet: PublicKey,
+  mint: PublicKey,
+) {
+  return (
+    await PublicKey.findProgramAddress(
+      [wallet.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mint.toBuffer()],
+      SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+    )
+  )[0];
+};
+
+export const getCandyMachineAddress = async (
+  config: anchor.web3.PublicKey,
+  uuid: string,
+) => {
+  return await anchor.web3.PublicKey.findProgramAddress(
+    [Buffer.from(CANDY_MACHINE), config.toBuffer(), Buffer.from(uuid)],
+    CANDY_MACHINE_PROGRAM_ID,
+  );
+};
+
+export const getConfig = async (
+  authority: anchor.web3.PublicKey,
+  uuid: string,
+) => {
+  return await anchor.web3.PublicKey.findProgramAddress(
+    [Buffer.from(CANDY_MACHINE), authority.toBuffer(), Buffer.from(uuid)],
+    CANDY_MACHINE_PROGRAM_ID,
+  );
+};
+
+export const getMetadata = async (
+  mint: anchor.web3.PublicKey,
+): Promise<anchor.web3.PublicKey> => {
+  return (
+    await anchor.web3.PublicKey.findProgramAddress(
+      [
+        Buffer.from('metadata'),
+        TOKEN_METADATA_PROGRAM_ID.toBuffer(),
+        mint.toBuffer(),
+      ],
+      TOKEN_METADATA_PROGRAM_ID,
+    )
+  )[0];
+};
+
+export const getMasterEdition = async (
+  mint: anchor.web3.PublicKey,
+): Promise<anchor.web3.PublicKey> => {
+  return (
+    await anchor.web3.PublicKey.findProgramAddress(
+      [
+        Buffer.from('metadata'),
+        TOKEN_METADATA_PROGRAM_ID.toBuffer(),
+        mint.toBuffer(),
+        Buffer.from('edition'),
+      ],
+      TOKEN_METADATA_PROGRAM_ID,
+    )
+  )[0];
+};
+
+export function loadWalletKey(keypair): Keypair {
+  return Keypair.fromSecretKey(
+    new Uint8Array(JSON.parse(fs.readFileSync(keypair).toString())),
+  );
+}
+
+export async function loadAnchorProgram(walletKeyPair: Keypair, env: string) {
+  const solConnection = new anchor.web3.Connection(
+    `https://api.${env}.solana.com/`,
+  );
+  const walletWrapper = new anchor.Wallet(walletKeyPair);
+  const provider = new anchor.Provider(solConnection, walletWrapper, {
+    preflightCommitment: 'recent',
+  });
+  const idl = await anchor.Program.fetchIdl(CANDY_MACHINE_PROGRAM_ID, provider);
+
+  return new anchor.Program(idl, CANDY_MACHINE_PROGRAM_ID, provider);
+}

--- a/js/packages/cli/src/helpers/constants.ts
+++ b/js/packages/cli/src/helpers/constants.ts
@@ -1,0 +1,42 @@
+import { PublicKey } from '@solana/web3.js';
+
+export const CANDY_MACHINE = 'candy_machine';
+
+export const PAYMENT_WALLET = new PublicKey(
+  'HvwC9QSAzvGXhhVrgPmauVwFWcYZhne3hVot9EbHuFTm',
+);
+export const CANDY_MACHINE_PROGRAM_ID = new PublicKey(
+  'cndyAnrLdpjq1Ssp1z8xxDsB8dxe7u4HL5Nxi2K5WXZ',
+);
+export const TOKEN_METADATA_PROGRAM_ID = new PublicKey(
+  'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+);
+export const SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID = new PublicKey(
+  'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
+);
+export const TOKEN_PROGRAM_ID = new PublicKey(
+  'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+);
+
+export const CONFIG_ARRAY_START =
+  32 + // authority
+  4 +
+  6 + // uuid + u32 len
+  4 +
+  10 + // u32 len + symbol
+  2 + // seller fee basis points
+  1 +
+  4 +
+  5 * 34 + // optional + u32 len + actual vec
+  8 + //max supply
+  1 + //is mutable
+  1 + // retain authority
+  4; // max number of lines;
+export const CONFIG_LINE_SIZE = 4 + 32 + 4 + 200;
+
+export const CACHE_PATH = './.cache';
+
+export const DEFAULT_TIMEOUT = 15000;
+
+export const EXTENSION_PNG = '.png';
+export const EXTENSION_JSON = '.json';

--- a/js/packages/cli/src/helpers/instructions.ts
+++ b/js/packages/cli/src/helpers/instructions.ts
@@ -1,0 +1,89 @@
+import {
+  PublicKey,
+  SystemProgram,
+  SYSVAR_RENT_PUBKEY,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import {
+  CANDY_MACHINE_PROGRAM_ID,
+  CONFIG_ARRAY_START,
+  CONFIG_LINE_SIZE,
+  SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from './constants';
+import * as anchor from '@project-serum/anchor';
+
+export function createAssociatedTokenAccountInstruction(
+  associatedTokenAddress: PublicKey,
+  payer: PublicKey,
+  walletAddress: PublicKey,
+  splTokenMintAddress: PublicKey,
+) {
+  const keys = [
+    {
+      pubkey: payer,
+      isSigner: true,
+      isWritable: true,
+    },
+    {
+      pubkey: associatedTokenAddress,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: walletAddress,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: splTokenMintAddress,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: SystemProgram.programId,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: TOKEN_PROGRAM_ID,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: SYSVAR_RENT_PUBKEY,
+      isSigner: false,
+      isWritable: false,
+    },
+  ];
+  return new TransactionInstruction({
+    keys,
+    programId: SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+    data: Buffer.from([]),
+  });
+}
+
+export async function createConfigAccount(
+  anchorProgram,
+  configData,
+  payerWallet,
+  configAccount,
+) {
+  const size =
+    CONFIG_ARRAY_START +
+    4 +
+    configData.maxNumberOfLines.toNumber() * CONFIG_LINE_SIZE +
+    4 +
+    Math.ceil(configData.maxNumberOfLines.toNumber() / 8);
+
+  return anchor.web3.SystemProgram.createAccount({
+    fromPubkey: payerWallet,
+    newAccountPubkey: configAccount,
+    space: size,
+    lamports:
+      await anchorProgram.provider.connection.getMinimumBalanceForRentExemption(
+        size,
+      ),
+    programId: CANDY_MACHINE_PROGRAM_ID,
+  });
+}

--- a/js/packages/cli/src/helpers/various.ts
+++ b/js/packages/cli/src/helpers/various.ts
@@ -1,0 +1,93 @@
+import { LAMPORTS_PER_SOL } from '@solana/web3.js';
+import { CACHE_PATH } from './constants';
+import path from 'path';
+import fs from 'fs';
+import FormData from 'form-data';
+import fetch from 'node-fetch';
+
+export const getUnixTs = () => {
+  return new Date().getTime() / 1000;
+};
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function fromUTF8Array(data: number[]) {
+  // array of bytes
+  let str = '',
+    i;
+
+  for (i = 0; i < data.length; i++) {
+    const value = data[i];
+
+    if (value < 0x80) {
+      str += String.fromCharCode(value);
+    } else if (value > 0xbf && value < 0xe0) {
+      str += String.fromCharCode(((value & 0x1f) << 6) | (data[i + 1] & 0x3f));
+      i += 1;
+    } else if (value > 0xdf && value < 0xf0) {
+      str += String.fromCharCode(
+        ((value & 0x0f) << 12) |
+          ((data[i + 1] & 0x3f) << 6) |
+          (data[i + 2] & 0x3f),
+      );
+      i += 2;
+    } else {
+      // surrogate pair
+      const charCode =
+        (((value & 0x07) << 18) |
+          ((data[i + 1] & 0x3f) << 12) |
+          ((data[i + 2] & 0x3f) << 6) |
+          (data[i + 3] & 0x3f)) -
+        0x010000;
+
+      str += String.fromCharCode(
+        (charCode >> 10) | 0xd800,
+        (charCode & 0x03ff) | 0xdc00,
+      );
+      i += 3;
+    }
+  }
+
+  return str;
+}
+
+export function chunks(array, size) {
+  return Array.apply(0, new Array(Math.ceil(array.length / size))).map(
+    (_, index) => array.slice(index * size, (index + 1) * size),
+  );
+}
+
+export function cachePath(env: string, cacheName: string) {
+  return path.join(CACHE_PATH, `${env}-${cacheName}`);
+}
+
+export function loadCache(cacheName: string, env: string) {
+  const path = cachePath(env, cacheName);
+  return fs.existsSync(path)
+    ? JSON.parse(fs.readFileSync(path).toString())
+    : undefined;
+}
+
+export function saveCache(cacheName: string, env: string, cacheContent) {
+  fs.writeFileSync(cachePath(env, cacheName), JSON.stringify(cacheContent));
+}
+
+export function parsePrice(price): number {
+  return Math.ceil(parseFloat(price) * LAMPORTS_PER_SOL);
+}
+
+export async function upload(data: FormData, manifest, index) {
+  console.log(`trying to upload ${index}.png: ${manifest.name}`);
+  return await (
+    await fetch(
+      'https://us-central1-principal-lane-200702.cloudfunctions.net/uploadFile4',
+      {
+        method: 'POST',
+        // @ts-ignore
+        body: data,
+      },
+    )
+  ).json();
+}

--- a/js/packages/cli/src/types.ts
+++ b/js/packages/cli/src/types.ts
@@ -1,0 +1,56 @@
+import {BN} from "@project-serum/anchor";
+import {PublicKey} from "@solana/web3.js";
+
+export class Creator {
+  address: string;
+  verified: boolean;
+  share: number;
+
+  constructor(args: {
+    address: string;
+    verified: boolean;
+    share: number;
+  }) {
+    this.address = args.address;
+    this.verified = args.verified;
+    this.share = args.share;
+  }
+}
+
+export interface Config {
+  authority: PublicKey;
+  data: ConfigData;
+}
+
+export class ConfigData {
+  name: string;
+  symbol: string;
+  uri: string;
+  sellerFeeBasisPoints: number;
+  creators: Creator[] | null;
+  maxNumberOfLines: BN | number;
+  isMutable: boolean;
+  maxSupply: BN;
+  retainAuthority: boolean;
+  constructor(args: {
+    name: string;
+    symbol: string;
+    uri: string;
+    sellerFeeBasisPoints: number;
+    creators: Creator[] | null;
+    maxNumberOfLines: BN;
+    isMutable: boolean;
+    maxSupply: BN;
+    retainAuthority: boolean;
+  }) {
+    this.name = args.name;
+    this.symbol = args.symbol;
+    this.uri = args.uri;
+    this.sellerFeeBasisPoints = args.sellerFeeBasisPoints;
+    this.creators = args.creators;
+    this.maxNumberOfLines = args.maxNumberOfLines;
+    this.isMutable = args.isMutable;
+    this.maxSupply = args.maxSupply;
+    this.retainAuthority = args.retainAuthority;
+  }
+}

--- a/rust/nft-candy-machine/src/lib.rs
+++ b/rust/nft-candy-machine/src/lib.rs
@@ -121,7 +121,7 @@ pub mod nft_candy_machine {
         for c in &config.data.creators {
             creators.push(spl_token_metadata::state::Creator {
                 address: c.address,
-                verified: false,
+                verified: true,
                 share: c.share,
             });
         }


### PR DESCRIPTION
* feat: candy-machine cli overhaul, so it's more readable

- extracted constants
- separated some helpers out
- removed duplication of crucial parts (like cache management, instruction creation, etc)
- renamed some variables to make them more accurate
- added `env` option and removed `url` option
- used env in all operations
- added some error handling

* more cleanups

* Add env option to bundler (#320)

* feature: add env to cli

* fix: format

* more cleanups

* added error checking

* eslint updates

* Some small bugfixes

Co-authored-by: Radoslaw Domanski <woohaas@gmail.com>
Co-authored-by: B <264380+bartosz-lipinski@users.noreply.github.com>